### PR TITLE
Account for top padding when adding the columns

### DIFF
--- a/CNN data2img/data2imgX1.m
+++ b/CNN data2img/data2imgX1.m
@@ -73,7 +73,7 @@ for ff = 1:totalExpFiles
         k = 1;
         %upside down images will be created
         for j = gap+1:gap+px:imgSz(2)-gap 
-           imgageGPU(px:barI(k),j:j+px-1,i) = 1; 
+           imgageGPU(px+1:barI(k)+px,j:j+px-1,i) = 1;
 
            k = k+1;
            if(k>d) 


### PR DESCRIPTION
With the previous code each column was drawn (values set to 1) top to bottom from position `px` to position `bar(I)`.

The starting position was correct, but the ending position was wrong as it didn't account for the columns being displaced downwards `px` pixels.